### PR TITLE
Add locking to booking service and concurrency regression test

### DIFF
--- a/booking/__init__.py
+++ b/booking/__init__.py
@@ -1,0 +1,10 @@
+"""Booking domain package."""
+
+from .service import BookingService, BookingConflictError, SlotUnavailableError, Booking
+
+__all__ = [
+    "Booking",
+    "BookingService",
+    "BookingConflictError",
+    "SlotUnavailableError",
+]

--- a/booking/service.py
+++ b/booking/service.py
@@ -1,0 +1,90 @@
+"""Core booking service implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Set
+import threading
+
+
+class BookingConflictError(RuntimeError):
+    """Raised when an attempt to create a booking conflicts with an existing one."""
+
+
+class SlotUnavailableError(RuntimeError):
+    """Raised when an agent has no availability for the requested slot."""
+
+
+@dataclass(frozen=True)
+class Booking:
+    """Represents a booking allocation for an agent."""
+
+    agent_id: str
+    slot: str
+    customer_id: str
+
+
+class BookingService:
+    """Provides a simple in-memory booking implementation with concurrency guarantees."""
+
+    def __init__(self) -> None:
+        self._availability: Dict[str, Set[str]] = {}
+        self._bookings: Dict[str, List[Booking]] = {}
+        self._lock = threading.Lock()
+
+    def set_availability(self, agent_id: str, slots: Iterable[str]) -> None:
+        """Define the exact set of available slots for an agent."""
+        with self._lock:
+            self._availability[agent_id] = set(slots)
+
+    def add_availability(self, agent_id: str, slot: str) -> None:
+        """Add a single availability slot for an agent."""
+        with self._lock:
+            self._availability.setdefault(agent_id, set()).add(slot)
+
+    def has_conflict(self, agent_id: str, slot: str) -> bool:
+        """Determine whether the given agent already has a booking for the slot."""
+        with self._lock:
+            return self._has_conflict_unlocked(agent_id, slot)
+
+    def list_bookings(self, agent_id: Optional[str] = None) -> List[Booking]:
+        """Return a copy of the bookings for the given agent or all bookings."""
+        with self._lock:
+            if agent_id is None:
+                return [booking for bookings in self._bookings.values() for booking in bookings]
+            return list(self._bookings.get(agent_id, ()))
+
+    def is_available(self, agent_id: str, slot: str) -> bool:
+        """Check if the agent has the requested slot available."""
+        with self._lock:
+            return slot in self._availability.get(agent_id, set())
+
+    def book(self, agent_id: str, slot: str, customer_id: str) -> Booking:
+        """Attempt to create a booking for the agent."""
+        # Perform an optimistic conflict check to fail fast when possible.
+        if self.has_conflict(agent_id, slot):
+            raise BookingConflictError(f"Agent {agent_id} already has a booking for slot {slot}.")
+
+        with self._lock:
+            available_slots = self._availability.get(agent_id, set())
+            if slot not in available_slots:
+                raise SlotUnavailableError(
+                    f"Agent {agent_id} is not available for slot {slot}."
+                )
+
+            if self._has_conflict_unlocked(agent_id, slot):
+                raise BookingConflictError(
+                    f"Agent {agent_id} already has a booking for slot {slot}."
+                )
+
+            booking = Booking(agent_id=agent_id, slot=slot, customer_id=customer_id)
+            self._bookings.setdefault(agent_id, []).append(booking)
+            available_slots.remove(slot)
+            if not available_slots:
+                # Keep our internal dict tidy by removing empty availability entries.
+                self._availability.pop(agent_id, None)
+            return booking
+
+    # Internal helpers -------------------------------------------------
+    def _has_conflict_unlocked(self, agent_id: str, slot: str) -> bool:
+        bookings = self._bookings.get(agent_id, ())
+        return any(existing.slot == slot for existing in bookings)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -1,0 +1,73 @@
+import threading
+from typing import List
+
+import pytest
+
+from booking import (
+    BookingConflictError,
+    BookingService,
+    SlotUnavailableError,
+)
+
+
+@pytest.fixture
+def service() -> BookingService:
+    svc = BookingService()
+    svc.add_availability("agent-1", "2025-01-01T09:00")
+    return svc
+
+
+def test_successful_booking_consumes_availability(service: BookingService) -> None:
+    booking = service.book("agent-1", "2025-01-01T09:00", "customer-1")
+
+    assert booking.customer_id == "customer-1"
+    assert not service.is_available("agent-1", "2025-01-01T09:00")
+    assert service.has_conflict("agent-1", "2025-01-01T09:00")
+
+
+def test_conflicting_booking_is_rejected(service: BookingService) -> None:
+    service.book("agent-1", "2025-01-01T09:00", "customer-1")
+
+    with pytest.raises(BookingConflictError):
+        service.book("agent-1", "2025-01-01T09:00", "customer-2")
+
+
+class ThreadResult:
+    def __init__(self) -> None:
+        self.successful: List[str] = []
+        self.failures: List[BaseException] = []
+        self.lock = threading.Lock()
+
+    def record_success(self, customer_id: str) -> None:
+        with self.lock:
+            self.successful.append(customer_id)
+
+    def record_failure(self, exc: BaseException) -> None:
+        with self.lock:
+            self.failures.append(exc)
+
+
+def test_multithreaded_conflict_protection() -> None:
+    service = BookingService()
+    service.add_availability("agent-1", "2025-01-01T09:00")
+
+    barrier = threading.Barrier(2)
+    results = ThreadResult()
+
+    def attempt_booking(customer: str) -> None:
+        try:
+            barrier.wait()
+            booking = service.book("agent-1", "2025-01-01T09:00", customer)
+        except (BookingConflictError, SlotUnavailableError) as exc:
+            results.record_failure(exc)
+        else:
+            results.record_success(booking.customer_id)
+
+    threads = [threading.Thread(target=attempt_booking, args=(customer,)) for customer in ("customer-1", "customer-2")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(results.successful) == 1
+    assert len(results.failures) == 1


### PR DESCRIPTION
## Summary
- add an in-memory `BookingService` that protects booking operations with a threading lock
- ensure conflicts are re-checked inside the critical section before persisting the booking
- add regression tests, including a multithreaded case, to assert only one booking succeeds per slot

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d7183389f88329ab6d645b4affd3fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a booking capability with agent availability management, booking creation, conflict detection, and thread-safe operations.
  * Clear, user-friendly errors when a slot is unavailable or a conflict occurs.
  * Simplified imports via the booking package’s public API.

* **Tests**
  * Added comprehensive tests covering successful bookings, conflict scenarios, and concurrent booking attempts.
  * Improved test setup to ensure the project is correctly discoverable during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->